### PR TITLE
Add built-in HMAC attestation provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ It demonstrates how a local service can securely connect to the Nexus mesh and h
 
 1.  **Configuration Driven:** The client reads a `config.yaml` file to determine which services to expose.
 2.  **Connects Outbound:** For each configured service, it initiates a WebSocket connection to a Nexus Proxy node.
-3.  **Presents Token:** It sends a complete, pre-signed JSON Web Token (JWT) provided in the config. The client itself has no access to the JWT secret.
-4.  **Listens for Commands:** It listens for simple JSON control messages from the proxy, primarily `connect` and `disconnect` commands.
-5.  **Active Health Checks:** The client actively monitors its connections. If a connection is idle for too long, it sends a `ping_client` message to the Nexus Proxy to verify the connection is still alive on the proxy side. If no `pong_client` is received, the client cleans up the local connection, preventing zombies.
-6.  **Host-Aware Relaying:** `portMappings` can now route by port, hostname, or single-label wildcard (e.g. `*.preview.example.com`), allowing one backend connection to front multiple virtual hosts.
+3.  **Performs TPM attestation:** Immediately after connecting, it runs the configured attestation command to fetch a Stage&nbsp;0 “handshake” token, sends it, waits for Nexus to issue a `handshake_challenge`, then produces a Stage&nbsp;1 token that embeds the provided `session_nonce`.
+4.  **Handles re-attestation:** Whenever Nexus pushes a `reauth_challenge`, the client reruns the attestation command (Stage&nbsp;`reauth`) and replies with the refreshed token without interrupting active streams.
+5.  **Listens for Commands:** It listens for JSON control messages from the proxy, primarily `connect` and `disconnect` commands.
+6.  **Active Health Checks:** The client actively monitors its connections. If a connection is idle for too long, it sends a `ping_client` message to the Nexus Proxy to verify the connection is still alive on the proxy side. If no `pong_client` is received, the client cleans up the local connection, preventing zombies.
+7.  **Host-Aware Relaying:** `portMappings` can route by port, hostname, or single-label wildcard (e.g. `*.preview.example.com`), allowing one backend connection to front multiple virtual hosts.
 
 ## Configuration
 
@@ -20,7 +21,9 @@ See [config.example.yaml](config.example.yaml).
 
 Key fields:
 
-- `hostnames`: list every FQDN (or `*.example.com` wildcard) this backend will serve. These must line up with the JWT claims you provision.
+- `hostnames`: list every FQDN (or `*.example.com` wildcard) this backend will serve. These must line up with the attestation claims issued by your authorizer.
+- `attestation`: describes how tokens are produced—either by running an external command or, when `hmacSecret`/`hmacSecretFile` is provided, by signing locally with HS256 (see [Attestation Command Contract](#attestation-command-contract)).
+- `weight`: optional integer advertised to Nexus for load-balancing decisions (defaults to `1`).
 - `portMappings`: maps the public Nexus port to a local target using a structured form that supports hostname-specific overrides:
 
     ```yaml
@@ -33,6 +36,34 @@ Key fields:
     ```
 
  Exact hostnames take precedence over wildcards, and wildcards only match a single label (e.g. `a.preview.example.com`).
+
+### Attestation Command Contract
+
+The client invokes the command specified under `attestation` for every Stage 0/1 exchange and subsequent re-authentication. The command is executed with these environment variables:
+
+- `NEXUS_ATTESTATION_STAGE`: one of `handshake`, `attest`, or `reauth`.
+- `NEXUS_SESSION_NONCE`: populated for Stage&nbsp;1 and re-auth requests (empty during the handshake stage).
+- `NEXUS_BACKEND_NAME`: the backend name from the config block.
+- `NEXUS_HOSTNAMES`: comma-separated list of hostnames associated with the backend.
+- `NEXUS_WEIGHT`: numeric weight advertised to Nexus.
+
+The command must print the signed JWT to stdout. Either of the following formats are accepted:
+
+```
+eyJhbGciOi...
+```
+
+or
+
+```json
+{"token":"eyJhbGciOi...","expiry":"2025-10-28T12:00:00Z"}
+```
+
+If `cacheHandshakeSeconds` is set in the config, handshake tokens are cached for that duration unless an explicit `expiry` is returned. All other stages are always fetched fresh.
+
+#### Built-in HMAC signer
+
+If you supply `attestation.hmacSecret` or `attestation.hmacSecretFile`, the client will skip the external command and sign JWTs locally using HS256. Optional fields such as `tokenTTLSeconds`, `reauthIntervalSeconds`, `reauthGraceSeconds`, and `maintenanceGraceCapSeconds` control the embedded claims. This is handy for environments that share a symmetric key with Nexus while they bring the TPM-based authorizer online.
 
 ### Example Usage
 
@@ -63,7 +94,10 @@ router := func(ctx context.Context, req client.ConnectRequest) (net.Conn, error)
     return nil, client.ErrNoRoute
 }
 
-c := client.New(cfg, client.WithConnectHandler(router))
+c, err := client.New(cfg, client.WithConnectHandler(router))
+if err != nil {
+    log.Fatalf("failed to construct Nexus client: %v", err)
+}
 go c.Start(ctx)
 ```
 

--- a/client/attestation.go
+++ b/client/attestation.go
@@ -1,0 +1,326 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// TokenStage identifies which step of the attestation workflow is requesting a token.
+type TokenStage string
+
+const (
+	StageHandshake     TokenStage = "handshake"
+	StageAttest        TokenStage = "attest"
+	StageReauth        TokenStage = "reauth"
+	attestEnvStage                = "NEXUS_ATTESTATION_STAGE"
+	attestEnvNonce                = "NEXUS_SESSION_NONCE"
+	attestEnvBackend              = "NEXUS_BACKEND_NAME"
+	attestEnvHostnames            = "NEXUS_HOSTNAMES"
+	attestEnvWeight               = "NEXUS_WEIGHT"
+)
+
+// Token encapsulates the token value and an optional expiry.
+type Token struct {
+	Value  string
+	Expiry time.Time
+}
+
+// TokenRequest conveys the contextual information for issuing a token.
+type TokenRequest struct {
+	Stage        TokenStage
+	SessionNonce string
+	BackendName  string
+	Hostnames    []string
+	Weight       int
+}
+
+// TokenProvider issues attestation tokens for a given request.
+type TokenProvider interface {
+	IssueToken(ctx context.Context, req TokenRequest) (Token, error)
+}
+
+// AttestationOptions contains configuration for generating attestation tokens.
+type AttestationOptions struct {
+	Command                    string
+	Args                       []string
+	Env                        map[string]string
+	Timeout                    time.Duration
+	CacheHandshake             time.Duration
+	HMACSecret                 string
+	HMACSecretFile             string
+	TokenTTL                   time.Duration
+	HandshakeMaxAgeSeconds     int
+	ReauthIntervalSeconds      int
+	ReauthGraceSeconds         int
+	MaintenanceGraceCapSeconds int
+	AuthorizerStatusURI        string
+	PolicyVersion              string
+}
+
+// CommandTokenProvider implements TokenProvider by invoking an external command.
+type CommandTokenProvider struct {
+	cfg            AttestationOptions
+	handshakeCache tokenCache
+}
+
+// tokenCache stores a cached token until its expiry.
+type tokenCache struct {
+	token  Token
+	expiry time.Time
+}
+
+func (tc *tokenCache) get(now time.Time) (Token, bool) {
+	if tc.expiry.IsZero() {
+		return Token{}, false
+	}
+	if now.After(tc.expiry) {
+		return Token{}, false
+	}
+	return tc.token, true
+}
+
+func (tc *tokenCache) set(tok Token, ttl time.Duration) {
+	if tok.Value == "" {
+		tc.token = Token{}
+		tc.expiry = time.Time{}
+		return
+	}
+	tc.token = tok
+	if tok.Expiry.IsZero() {
+		if ttl <= 0 {
+			tc.expiry = time.Time{}
+			return
+		}
+		tc.expiry = time.Now().Add(ttl)
+		return
+	}
+	tc.expiry = tok.Expiry
+}
+
+// NewCommandTokenProvider returns a TokenProvider backed by an external command.
+func NewCommandTokenProvider(cfg AttestationOptions) (*CommandTokenProvider, error) {
+	if strings.TrimSpace(cfg.Command) == "" {
+		return nil, fmt.Errorf("attestation command is required")
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 15 * time.Second
+	}
+	return &CommandTokenProvider{cfg: cfg}, nil
+}
+
+// IssueToken invokes the configured command to retrieve an attestation token.
+func (c *CommandTokenProvider) IssueToken(ctx context.Context, req TokenRequest) (Token, error) {
+	if req.Stage == StageHandshake && c.cfg.CacheHandshake > 0 {
+		if tok, ok := c.handshakeCache.get(time.Now()); ok {
+			return tok, nil
+		}
+	}
+
+	cmdCtx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(cmdCtx, c.cfg.Command, c.cfg.Args...)
+	cmd.Env = append(os.Environ(), formatEnv(c.cfg.Env)...)
+	cmd.Env = append(cmd.Env,
+		fmt.Sprintf("%s=%s", attestEnvStage, string(req.Stage)),
+		fmt.Sprintf("%s=%s", attestEnvBackend, req.BackendName),
+		fmt.Sprintf("%s=%s", attestEnvHostnames, strings.Join(req.Hostnames, ",")),
+		fmt.Sprintf("%s=%d", attestEnvWeight, req.Weight),
+	)
+	if req.Stage != StageHandshake {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", attestEnvNonce, req.SessionNonce))
+	} else {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=", attestEnvNonce))
+	}
+
+	out, err := cmd.CombinedOutput()
+	if ctxErr := cmdCtx.Err(); ctxErr != nil && ctxErr != context.Canceled {
+		return Token{}, fmt.Errorf("attestation command timed out: %w", ctxErr)
+	}
+	if err != nil {
+		return Token{}, fmt.Errorf("attestation command failed: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	tok, err := parseTokenOutput(out)
+	if err != nil {
+		return Token{}, err
+	}
+
+	if req.Stage == StageHandshake && c.cfg.CacheHandshake > 0 && tok.Value != "" {
+		c.handshakeCache.set(tok, c.cfg.CacheHandshake)
+	}
+
+	return tok, nil
+}
+
+func formatEnv(extra map[string]string) []string {
+	if len(extra) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(extra))
+	for k, v := range extra {
+		out = append(out, fmt.Sprintf("%s=%s", k, v))
+	}
+	return out
+}
+
+func parseTokenOutput(raw []byte) (Token, error) {
+	payload := strings.TrimSpace(string(raw))
+	if payload == "" {
+		return Token{}, fmt.Errorf("attestation command returned empty token")
+	}
+
+	if strings.HasPrefix(payload, "{") {
+		var resp struct {
+			Token  string `json:"token"`
+			Expiry string `json:"expiry"`
+		}
+		if err := json.Unmarshal([]byte(payload), &resp); err != nil {
+			return Token{}, fmt.Errorf("failed to decode attestation command JSON: %w", err)
+		}
+		if strings.TrimSpace(resp.Token) == "" {
+			return Token{}, fmt.Errorf("attestation command JSON missing token")
+		}
+		tok := Token{Value: strings.TrimSpace(resp.Token)}
+		if resp.Expiry != "" {
+			if ts, err := time.Parse(time.RFC3339, resp.Expiry); err == nil {
+				tok.Expiry = ts
+			}
+		}
+		return tok, nil
+	}
+
+	lines := strings.Split(payload, "\n")
+	tokenValue := strings.TrimSpace(lines[0])
+	if tokenValue == "" {
+		return Token{}, fmt.Errorf("attestation command output did not contain a token")
+	}
+	return Token{Value: tokenValue}, nil
+}
+
+// HMACTokenProvider produces tokens signed with a shared secret.
+type HMACTokenProvider struct {
+	secret         []byte
+	opts           AttestationOptions
+	backendName    string
+	hostnames      []string
+	weight         int
+	handshakeCache tokenCache
+}
+
+// NewHMACTokenProvider returns a TokenProvider that signs JWTs locally using HS256.
+func NewHMACTokenProvider(opts AttestationOptions, backendName string, hostnames []string, weight int) (*HMACTokenProvider, error) {
+	secret := strings.TrimSpace(opts.HMACSecret)
+	if opts.HMACSecretFile != "" {
+		data, err := os.ReadFile(opts.HMACSecretFile)
+		if err != nil {
+			return nil, fmt.Errorf("read hmac secret file: %w", err)
+		}
+		secret = strings.TrimSpace(string(bytes.TrimSpace(data)))
+	}
+	if secret == "" {
+		return nil, errors.New("hmac secret is required")
+	}
+
+	provider := &HMACTokenProvider{
+		secret:      []byte(secret),
+		opts:        opts,
+		backendName: backendName,
+		hostnames:   append([]string(nil), hostnames...),
+		weight:      weight,
+	}
+	return provider, nil
+}
+
+// IssueToken signs a JWT that encodes the attestation claims expected by Nexus.
+func (h *HMACTokenProvider) IssueToken(ctx context.Context, req TokenRequest) (Token, error) {
+	if req.Stage == StageHandshake && h.opts.CacheHandshake > 0 {
+		if tok, ok := h.handshakeCache.get(time.Now()); ok {
+			return tok, nil
+		}
+	}
+
+	now := time.Now()
+	ttl := h.opts.TokenTTL
+	if ttl <= 0 {
+		ttl = 30 * time.Second
+	}
+	exp := now.Add(ttl)
+
+	claims := attestationClaims{
+		Hostnames: append([]string(nil), h.hostnames...),
+		Weight:    h.weight,
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    "authorizer",
+			Subject:   h.backendName,
+			Audience:  jwt.ClaimStrings{"nexus"},
+			IssuedAt:  jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(exp),
+		},
+	}
+
+	if req.Stage != StageHandshake {
+		claims.SessionNonce = req.SessionNonce
+	} else if h.opts.HandshakeMaxAgeSeconds > 0 {
+		claims.HandshakeMaxAgeSeconds = optionalInt(h.opts.HandshakeMaxAgeSeconds)
+	}
+
+	if h.opts.ReauthIntervalSeconds > 0 {
+		claims.ReauthIntervalSeconds = optionalInt(h.opts.ReauthIntervalSeconds)
+	}
+	if h.opts.ReauthGraceSeconds > 0 {
+		claims.ReauthGraceSeconds = optionalInt(h.opts.ReauthGraceSeconds)
+	}
+	if h.opts.MaintenanceGraceCapSeconds > 0 {
+		claims.MaintenanceGraceCapSeconds = optionalInt(h.opts.MaintenanceGraceCapSeconds)
+	}
+	if h.opts.AuthorizerStatusURI != "" {
+		claims.AuthorizerStatusURI = h.opts.AuthorizerStatusURI
+	}
+	if h.opts.PolicyVersion != "" {
+		claims.PolicyVersion = h.opts.PolicyVersion
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(h.secret)
+	if err != nil {
+		return Token{}, fmt.Errorf("sign token: %w", err)
+	}
+
+	result := Token{Value: signed, Expiry: exp}
+	if req.Stage == StageHandshake && h.opts.CacheHandshake > 0 {
+		h.handshakeCache.set(result, h.opts.CacheHandshake)
+	}
+
+	return result, nil
+}
+
+func optionalInt(val int) *int {
+	if val <= 0 {
+		return nil
+	}
+	v := val
+	return &v
+}
+
+type attestationClaims struct {
+	Hostnames                  []string `json:"hostnames"`
+	Weight                     int      `json:"weight"`
+	SessionNonce               string   `json:"session_nonce,omitempty"`
+	HandshakeMaxAgeSeconds     *int     `json:"handshake_max_age_seconds,omitempty"`
+	ReauthIntervalSeconds      *int     `json:"reauth_interval_seconds,omitempty"`
+	ReauthGraceSeconds         *int     `json:"reauth_grace_seconds,omitempty"`
+	MaintenanceGraceCapSeconds *int     `json:"maintenance_grace_cap_seconds,omitempty"`
+	AuthorizerStatusURI        string   `json:"authorizer_status_uri,omitempty"`
+	PolicyVersion              string   `json:"policy_version,omitempty"`
+	jwt.RegisteredClaims
+}

--- a/client/attestation_test.go
+++ b/client/attestation_test.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestHMACTokenProviderProducesExpectedClaims(t *testing.T) {
+	opts := AttestationOptions{
+		HMACSecret:                 "super-secret",
+		TokenTTL:                   60 * time.Second,
+		ReauthIntervalSeconds:      300,
+		ReauthGraceSeconds:         20,
+		MaintenanceGraceCapSeconds: 600,
+		HandshakeMaxAgeSeconds:     5,
+	}
+
+	provider, err := NewHMACTokenProvider(opts, "backend", []string{"example.com"}, 2)
+	if err != nil {
+		t.Fatalf("failed to build provider: %v", err)
+	}
+
+	handshake, err := provider.IssueToken(context.Background(), TokenRequest{
+		Stage:       StageHandshake,
+		BackendName: "backend",
+		Hostnames:   []string{"example.com"},
+		Weight:      2,
+	})
+	if err != nil {
+		t.Fatalf("handshake token failed: %v", err)
+	}
+
+	parse := func(tok string) jwt.MapClaims {
+		parser := jwt.NewParser()
+		token, _, err := parser.ParseUnverified(tok, jwt.MapClaims{})
+		if err != nil {
+			t.Fatalf("failed to parse token: %v", err)
+		}
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			t.Fatalf("unexpected claims type: %T", token.Claims)
+		}
+		return claims
+	}
+
+	handshakeClaims := parse(handshake.Value)
+	if _, ok := handshakeClaims["session_nonce"]; ok {
+		t.Fatalf("expected handshake token to omit session_nonce")
+	}
+	if handshakeClaims["weight"].(float64) != 2 {
+		t.Fatalf("expected weight=2, got %v", handshakeClaims["weight"])
+	}
+
+	reauth, err := provider.IssueToken(context.Background(), TokenRequest{
+		Stage:        StageReauth,
+		BackendName:  "backend",
+		Hostnames:    []string{"example.com"},
+		Weight:       2,
+		SessionNonce: "nonce123",
+	})
+	if err != nil {
+		t.Fatalf("reauth token failed: %v", err)
+	}
+
+	reauthClaims := parse(reauth.Value)
+	if got := reauthClaims["session_nonce"]; got != "nonce123" {
+		t.Fatalf("expected session_nonce 'nonce123', got %v", got)
+	}
+	if got := reauthClaims["reauth_interval_seconds"]; got != float64(300) {
+		t.Fatalf("expected reauth interval claim, got %v", got)
+	}
+}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -10,8 +10,17 @@ backends:
     nexusAddresses:
       - "wss://nexus-1.example.com/connect"
       - "wss://nexus-2.example.com/connect"
-    # The full, pre-signed JWT obtained from a central authorizer.
-    authToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    # Optional weight advertised to Nexus for load-balancing decisions (defaults to 1).
+    weight: 2
+    # Command that obtains handshake and attested tokens from your authorizer.
+    attestation:
+      command: "/usr/local/bin/nexus-attestor"
+      args:
+        - "--backend=edge-apps"
+      env:
+        AUTHORIZER_BASE_URL: "https://authorizer.example.com"
+      timeoutSeconds: 20
+      cacheHandshakeSeconds: 30
     # A map of public-facing relay ports on Nexus to local service targets.
     portMappings:
       443:
@@ -35,6 +44,10 @@ backends:
       - "imap.example.com"
     nexusAddresses:
       - "wss://nexus.example.com/connect"
-    authToken: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    attestation:
+      hmacSecretFile: "/etc/nexus/email-hmac.key"
+      tokenTTLSeconds: 45
+      reauthIntervalSeconds: 900
+      reauthGraceSeconds: 15
     portMappings:
       993: "localhost:993" # Relay secure IMAP (IMAPS) traffic

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+require github.com/golang-jwt/jwt/v5 v5.2.1
+
 require (
 	golang.org/x/net v0.17.0
 	golang.org/x/text v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=


### PR DESCRIPTION
## Summary
- add AttestationOptions and allow either external command or local HMAC signer
- update config/CLI/docs to support shared-secret deployments alongside TPM flow
- enhance tests covering re-auth handling, config validation, and JWT claims

## Testing
- go test ./...
